### PR TITLE
Add workflow duration and memory metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Access the editor at http://localhost:5678
 - 👥 [Community Forum](https://community.n8n.io)
 - 📖 [Community Tutorials](https://community.n8n.io/c/tutorials/28)
 
+## Metrics configuration
+
+Set `N8N_METRICS` to `true` to expose Prometheus metrics at `/metrics`.
+Use `N8N_METRICS_INCLUDE_WORKFLOW_DURATION` to enable workflow duration histograms
+and `N8N_METRICS_INCLUDE_WORKFLOW_MEMORY` to collect memory usage metrics.
+
 ## Support
 
 Need help? Our community forum is the place to get support and connect with other users:

--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -62,9 +62,17 @@ class PrometheusMetricsConfig {
 	@Env('N8N_METRICS_ACTIVE_WORKFLOW_METRIC_INTERVAL')
 	activeWorkflowCountInterval: number = 60;
 
-	/** Whether to include a label for workflow name on workflow metrics. */
-	@Env('N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL')
-	includeWorkflowNameLabel: boolean = false;
+        /** Whether to include a label for workflow name on workflow metrics. */
+        @Env('N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL')
+        includeWorkflowNameLabel: boolean = false;
+
+        /** Whether to expose execution duration histograms. */
+        @Env('N8N_METRICS_INCLUDE_WORKFLOW_DURATION')
+        includeWorkflowDuration: boolean = false;
+
+        /** Whether to expose execution memory usage metrics. */
+        @Env('N8N_METRICS_INCLUDE_WORKFLOW_MEMORY')
+        includeWorkflowMemory: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -177,8 +177,10 @@ describe('GlobalConfig', () => {
 				enable: false,
 				prefix: 'n8n_',
 				includeWorkflowIdLabel: false,
-				includeWorkflowNameLabel: false,
-				includeDefaultMetrics: true,
+                                includeWorkflowNameLabel: false,
+                                includeWorkflowDuration: false,
+                                includeWorkflowMemory: false,
+                                includeDefaultMetrics: true,
 				includeMessageEventBusMetrics: false,
 				includeNodeTypeLabel: false,
 				includeCacheMetrics: false,
@@ -391,10 +393,10 @@ describe('GlobalConfig', () => {
 			},
 			endpoints: {
 				...defaultConfig.endpoints,
-				metrics: {
-					...defaultConfig.endpoints.metrics,
-					enable: true,
-				},
+                                metrics: {
+                                        ...defaultConfig.endpoints.metrics,
+                                        enable: true,
+                                },
 			},
 			nodes: {
 				...defaultConfig.nodes,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -75,9 +75,10 @@ describe('PrometheusMetricsService', () => {
 			workflowRepository,
 		);
 
-		promClient.Counter.prototype.inc = jest.fn();
-		(promClient.validateMetricName as jest.Mock).mockReturnValue(true);
-	});
+                promClient.Counter.prototype.inc = jest.fn();
+                (promClient.validateMetricName as jest.Mock).mockReturnValue(true);
+               promClient.Histogram.prototype.observe = jest.fn();
+        });
 
 	afterEach(() => {
 		jest.clearAllMocks();
@@ -270,7 +271,7 @@ describe('PrometheusMetricsService', () => {
 		});
 	});
 
-	describe('when event bus events are sent', () => {
+        describe('when event bus events are sent', () => {
 		// Helper to find the event handler function registered by initEventBusMetrics
 		const getEventHandler = () => {
 			const eventBusOnCall = (eventBus.on as jest.Mock).mock.calls.find(
@@ -509,8 +510,8 @@ describe('PrometheusMetricsService', () => {
 			);
 		});
 
-		it('should create a counter with no labels if the corresponding config is disabled', async () => {
-			prometheusMetricsService.enableMetric('logs');
+                it('should create a counter with no labels if the corresponding config is disabled', async () => {
+                        prometheusMetricsService.enableMetric('logs');
 			await prometheusMetricsService.init(app);
 
 			const eventHandler = getEventHandler();
@@ -527,7 +528,50 @@ describe('PrometheusMetricsService', () => {
 				labelNames: [], // Expecting no labels
 			});
 
-			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({}, 1);
-		});
-	});
+                        expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({}, 1);
+                });
+        });
+
+        describe('workflow execution metrics', () => {
+                const getPreHandler = () => (eventService.on as jest.Mock).mock.calls.find((c) => c[0] === 'workflow-pre-execute')?.[1];
+                const getPostHandler = () => (eventService.on as jest.Mock).mock.calls.find((c) => c[0] === 'workflow-post-execute')?.[1];
+
+                it('records duration and memory usage', async () => {
+                        globalConfig.endpoints.metrics.includeWorkflowDuration = true;
+                        globalConfig.endpoints.metrics.includeWorkflowMemory = true;
+
+                        await prometheusMetricsService.init(app);
+
+                        const pre = getPreHandler();
+                        const post = getPostHandler();
+
+                        expect(pre).toBeDefined();
+                        expect(post).toBeDefined();
+
+                        jest.spyOn(process, 'memoryUsage').mockReturnValueOnce({ rss: 1000 } as any).mockReturnValueOnce({ rss: 1500 } as any);
+
+                        pre?.({ executionId: '1', data: {} } as any);
+                        post?.({
+                                executionId: '1',
+                                workflow: { id: 'wf1', name: 'Wf' },
+                                runData: { startedAt: new Date(0), stoppedAt: new Date(1000) },
+                        } as any);
+
+                        expect(promClient.Histogram).toHaveBeenCalledWith({
+                                name: 'n8n_workflow_duration_seconds',
+                                help: 'Workflow execution duration in seconds.',
+                                labelNames: [],
+                        });
+                        expect(promClient.Histogram).toHaveBeenCalledWith({
+                                name: 'n8n_workflow_memory_bytes',
+                                help: 'Workflow memory usage in bytes.',
+                                labelNames: [],
+                        });
+
+                        // @ts-expect-error private field
+                        expect(prometheusMetricsService.histograms.workflowDuration.observe).toHaveBeenCalledWith({}, 1);
+                        // @ts-expect-error private field
+                        expect(prometheusMetricsService.histograms.workflowMemory.observe).toHaveBeenCalledWith({}, 500);
+                });
+        });
 });

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
@@ -227,3 +227,50 @@ active_workflow_count 2"
 `);
 	});
 });
+
+describe('workflow execution metrics', () => {
+        test('records duration and memory', async () => {
+                const globalConfig = mockInstance(GlobalConfig, {
+                        endpoints: {
+                                metrics: {
+                                        prefix: '',
+                                        includeWorkflowDuration: true,
+                                        includeWorkflowMemory: true,
+                                },
+                        },
+                });
+
+                const localEventService = new EventService();
+
+                const prometheusMetricsService = new PrometheusMetricsService(
+                        cacheService,
+                        eventBus,
+                        globalConfig,
+                        localEventService,
+                        instanceSettings,
+                        workflowRepository,
+                );
+
+                await prometheusMetricsService.init(app);
+
+                jest
+                        .spyOn(process, 'memoryUsage')
+                        .mockReturnValueOnce({ rss: 1000 } as any)
+                        .mockReturnValueOnce({ rss: 1500 } as any);
+
+                localEventService.emit('workflow-pre-execute', { executionId: '1', data: {} } as any);
+                localEventService.emit('workflow-post-execute', {
+                        executionId: '1',
+                        workflow: { id: 'wf1', name: 'wf' },
+                        runData: { startedAt: new Date(0), stoppedAt: new Date(1000) },
+                } as any);
+
+                const durationMetric = await promClient.register.getSingleMetricAsString('workflow_duration_seconds');
+                expect(durationMetric).toContain('# TYPE workflow_duration_seconds histogram');
+                expect(durationMetric).toContain('workflow_duration_seconds_sum 1');
+
+                const memoryMetric = await promClient.register.getSingleMetricAsString('workflow_memory_bytes');
+                expect(memoryMetric).toContain('# TYPE workflow_memory_bytes histogram');
+                expect(memoryMetric).toContain('workflow_memory_bytes_sum 500');
+        });
+});

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -7,7 +7,7 @@ import promBundle from 'express-prom-bundle';
 import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames } from 'n8n-workflow';
-import promClient, { type Counter, type Gauge } from 'prom-client';
+import promClient, { type Counter, type Gauge, type Histogram } from 'prom-client';
 import semverParse from 'semver/functions/parse';
 
 import config from '@/config';
@@ -34,6 +34,10 @@ export class PrometheusMetricsService {
 
 	private readonly gauges: Record<string, Gauge<string>> = {};
 
+	private readonly histograms: Record<string, Histogram<string>> = {};
+
+	private readonly workflowMemoryStart = new Map<string, number>();
+
 	private readonly prefix = this.globalConfig.endpoints.metrics.prefix;
 
 	private readonly includes: Includes = {
@@ -55,6 +59,13 @@ export class PrometheusMetricsService {
 		},
 	};
 
+	private getWorkflowLabelNames(): string[] {
+		const names: string[] = [];
+		if (this.includes.labels.workflowId) names.push('workflow_id');
+		if (this.includes.labels.workflowName) names.push('workflow_name');
+		return names;
+	}
+
 	async init(app: express.Application) {
 		promClient.register.clear(); // clear all metrics in case we call this a second time
 		this.initDefaultMetrics();
@@ -64,6 +75,7 @@ export class PrometheusMetricsService {
 		this.initRouteMetrics(app);
 		this.initQueueMetrics();
 		this.initActiveWorkflowCountMetric();
+		this.initWorkflowMetrics();
 		this.mountMetricsEndpoint(app);
 	}
 
@@ -308,6 +320,55 @@ export class PrometheusMetricsService {
 					this.set(activeWorkflowCount);
 				}
 			},
+		});
+	}
+
+	private initWorkflowMetrics() {
+		const { includeWorkflowDuration, includeWorkflowMemory } = this.globalConfig.endpoints.metrics;
+
+		if (!includeWorkflowDuration && !includeWorkflowMemory) return;
+
+		const labelNames = this.getWorkflowLabelNames();
+
+		if (includeWorkflowDuration) {
+			this.histograms.workflowDuration = new promClient.Histogram({
+				name: this.prefix + 'workflow_duration_seconds',
+				help: 'Workflow execution duration in seconds.',
+				labelNames,
+			});
+		}
+
+		if (includeWorkflowMemory) {
+			this.histograms.workflowMemory = new promClient.Histogram({
+				name: this.prefix + 'workflow_memory_bytes',
+				help: 'Workflow memory usage in bytes.',
+				labelNames,
+			});
+
+			this.eventService.on('workflow-pre-execute', ({ executionId }) => {
+				this.workflowMemoryStart.set(executionId, process.memoryUsage().rss);
+			});
+		}
+
+		this.eventService.on('workflow-post-execute', ({ executionId, workflow, runData }) => {
+			const labels = this.buildWorkflowLabels({
+				workflowId: workflow.id,
+				workflowName: workflow.name,
+			});
+
+			if (includeWorkflowDuration && runData?.startedAt && runData.stoppedAt) {
+				const duration = (runData.stoppedAt.getTime() - runData.startedAt.getTime()) / 1000;
+				this.histograms.workflowDuration.observe(labels, duration);
+			}
+
+			if (includeWorkflowMemory) {
+				const start = this.workflowMemoryStart.get(executionId);
+				if (start !== undefined) {
+					const diff = process.memoryUsage().rss - start;
+					this.histograms.workflowMemory.observe(labels, diff);
+					this.workflowMemoryStart.delete(executionId);
+				}
+			}
 		});
 	}
 


### PR DESCRIPTION
## Summary
- extend PrometheusMetricsConfig with workflow duration and memory options
- capture execution duration and memory usage in PrometheusMetricsService
- test workflow duration/memory metrics
- document new metrics environment variables
- measure memory usage per execution with a Map to support concurrent workflows

## Testing
- `pnpm test:backend` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_687f54090f10832d827b727f9f33820a